### PR TITLE
Use KV tables and skip __index calls

### DIFF
--- a/lua/ulib/server/entity_ext.lua
+++ b/lua/ulib/server/entity_ext.lua
@@ -76,9 +76,6 @@ for _, v in ipairs( ULib.moveWhitelist ) do
 end
 
 local getTable = meta.GetTable
-local function getKey( ent, key )
-	return getTable( ent )[key]
-end
 
 -- Extended Entity meta and hooks
 function meta:DisallowMoving( bool )
@@ -122,29 +119,29 @@ local function tool( ply, tr, toolmode, second )
 		end
 	end
 
-	if getKey( tr.Entity, "NoMoving" ) and not moveWhitelist[toolmode] then
+	if getTable( tr.Entity ).NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
 
-	if getKey( tr.Entity, "NoDeleting" ) and not delWhitelist[toolmode] then
+	if getTable( tr.Entity ).NoDeleting and not delWhitelist[toolmode] then
 		return false
 	end
 end
 hook.Add( "CanTool", "ULibEntToolCheck", tool, HOOK_HIGH )
 
 local function property( _, _, ent )
-	if getKey( ent, "NoMoving" ) and not moveWhitelist[toolmode] then
+	if getTable( ent ).NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
 
-	if getKey( ent, "NoDeleting" ) and not delWhitelist[toolmode] then
+	if getTable( ent ).NoDeleting and not delWhitelist[toolmode] then
 		return false
 	end
 end
 hook.Add( "CanProperty", "ULibEntPropertyCheck", property, HOOK_HIGH )
 
 local function physgun( _, ent )
-	if getKey( ent, "NoMoving" ) then return false end
+	if getTable( ent ).NoMoving then return false end
 end
 hook.Add( "PhysgunPickup", "ULibEntPhysCheck", physgun, HOOK_HIGH )
 hook.Add( "CanPlayerUnfreeze", "ULibEntUnfreezeCheck", physgun, HOOK_HIGH )
@@ -155,13 +152,13 @@ local function physgunReload( _, ply )
 
 	local ent = tr.Entity
 	if not ent or not ent:IsValid() or ent:IsWorld() then return end -- Invalid or not interested
-	if getKey( ent, "NoMoving" ) then return false end
+	if getTable( ent ).NoMoving then return false end
 end
 hook.Add( "OnPhysgunReload", "ULibEntPhysReloadCheck", physgunReload, HOOK_HIGH )
 
 -- This is just in case we have some horribly programmed addon that goes rampant in deleting things
 local function removedCheck( ent )
-	if getKey( ent, "NoDeleting" ) and not getKey( ent, "NoReplication" ) then
+	if getTable( ent ).NoDeleting and not getTable( ent ).NoReplication then
 		local class = ent:GetClass()
 		local pos = ent:GetPos()
 		local ang = ent:GetAngles()

--- a/lua/ulib/server/entity_ext.lua
+++ b/lua/ulib/server/entity_ext.lua
@@ -1,7 +1,6 @@
 local meta = FindMetaTable( "Entity" )
 if not meta then return end
 
-
 -- Are you a STOOL author who's angry that your tool isn't on this list?
 -- Just add this to your code:
 -- if ULib then table.insert( ULib.delWhiteList, "my_stool" ) end
@@ -119,22 +118,24 @@ local function tool( ply, tr, toolmode, second )
 		end
 	end
 
-	if getTable( tr.Entity ).NoMoving and not moveWhitelist[toolmode] then
+    local trTable = getTable( tr.Entity )
+	if trTable.NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
 
-	if getTable( tr.Entity ).NoDeleting and not delWhitelist[toolmode] then
+	if trTable.NoDeleting and not delWhitelist[toolmode] then
 		return false
 	end
 end
 hook.Add( "CanTool", "ULibEntToolCheck", tool, HOOK_HIGH )
 
 local function property( _, _, ent )
-	if getTable( ent ).NoMoving and not moveWhitelist[toolmode] then
+    local entTable = getTable( ent )
+	if entTable.NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
 
-	if getTable( ent ).NoDeleting and not delWhitelist[toolmode] then
+	if entTable.NoDeleting and not delWhitelist[toolmode] then
 		return false
 	end
 end
@@ -158,7 +159,8 @@ hook.Add( "OnPhysgunReload", "ULibEntPhysReloadCheck", physgunReload, HOOK_HIGH 
 
 -- This is just in case we have some horribly programmed addon that goes rampant in deleting things
 local function removedCheck( ent )
-	if getTable( ent ).NoDeleting and not getTable( ent ).NoReplication then
+    local entTable = getTable( ent )
+	if entTable.NoDeleting and not entTable.NoReplication then
 		local class = ent:GetClass()
 		local pos = ent:GetPos()
 		local ang = ent:GetAngles()

--- a/lua/ulib/server/entity_ext.lua
+++ b/lua/ulib/server/entity_ext.lua
@@ -1,6 +1,4 @@
 local meta = FindMetaTable( "Entity" )
-
--- Return if there's nothing to add on to
 if not meta then return end
 
 
@@ -40,7 +38,7 @@ ULib.delWhitelist = -- White list for objects that can't be deleted
 	"statue",
 	"weld_ez",
 	"axis",
-	
+
 	-- Properties
 	"gravity",
 	"collision",
@@ -60,12 +58,29 @@ ULib.moveWhitelist = -- White list for objects that can't be moved
 	"eyeposer",
 	"faceposer",
 	"remover",
-	
+
 	-- Properties
 	--"remover", -- Already above
 	"persist",
 }
 
+-- Performance enhancement
+local delWhitelist = {}
+for _, v in ipairs( ULib.delWhitelist ) do
+	delWhitelist[v] = true
+end
+
+local moveWhitelist = {}
+for _, v in ipairs( ULib.moveWhitelist ) do
+	moveWhitelist[v] = true
+end
+
+local getTable = meta.GetTable
+local function getKey( ent, key )
+	return getTable( ent )[key]
+end
+
+-- Extended Entity meta and hooks
 function meta:DisallowMoving( bool )
 	self.NoMoving = bool
 end
@@ -107,61 +122,46 @@ local function tool( ply, tr, toolmode, second )
 		end
 	end
 
-	if tr.Entity.NoMoving then
-		if not table.HasValue( ULib.moveWhitelist, toolmode ) then
-			return false
-		end
+	if getKey( tr.Entity, "NoMoving" ) and not moveWhitelist[toolmode] then
+		return false
 	end
 
-	if tr.Entity.NoDeleting then
-		if not table.HasValue( ULib.delWhitelist, toolmode ) then
-			return false
-		end
+	if getKey( tr.Entity, "NoDeleting" ) and not delWhitelist[toolmode] then
+		return false
 	end
 end
 hook.Add( "CanTool", "ULibEntToolCheck", tool, HOOK_HIGH )
 
-local function property( ply, propertymode, ent )
-	if ent.NoMoving then
-		if not table.HasValue( ULib.moveWhitelist, toolmode ) then
-			return false
-		end
+local function property( _, _, ent )
+	if getKey( ent, "NoMoving" ) and not moveWhitelist[toolmode] then
+		return false
 	end
-	
-	if ent.NoDeleting then
-		if not table.HasValue( ULib.delWhitelist, toolmode ) then
-			return false
-		end
+
+	if getKey( ent, "NoDeleting" ) and not delWhitelist[toolmode] then
+		return false
 	end
 end
 hook.Add( "CanProperty", "ULibEntPropertyCheck", property, HOOK_HIGH )
 
-local function physgun( ply, ent )
-	if ent.NoMoving then return false end
+local function physgun( _, ent )
+	if getKey( ent, "NoMoving" ) then return false end
 end
 hook.Add( "PhysgunPickup", "ULibEntPhysCheck", physgun, HOOK_HIGH )
 hook.Add( "CanPlayerUnfreeze", "ULibEntUnfreezeCheck", physgun, HOOK_HIGH )
 
-local function physgunReload( weapon, ply )
+local function physgunReload( _, ply )
 	local trace = util.GetPlayerTrace( ply )
 	local tr = util.TraceLine( trace )
 
 	local ent = tr.Entity
 	if not ent or not ent:IsValid() or ent:IsWorld() then return end -- Invalid or not interested
-	if ent.NoMoving then return false end
+	if getKey( ent, "NoMoving" ) then return false end
 end
 hook.Add( "OnPhysgunReload", "ULibEntPhysReloadCheck", physgunReload, HOOK_HIGH )
 
-local function damageCheck( ent )
-	if ent.NoDeleting then
-		-- return false
-	end
-end
-hook.Add( "EntityTakeDamage", "ULibEntDamagedCheck", damageCheck, HOOK_MONITOR_HIGH )
-
 -- This is just in case we have some horribly programmed addon that goes rampant in deleting things
 local function removedCheck( ent )
-	if ent.NoDeleting and not ent.NoReplication then
+	if getKey( ent, "NoDeleting" ) and not getKey( ent, "NoReplication" ) then
 		local class = ent:GetClass()
 		local pos = ent:GetPos()
 		local ang = ent:GetAngles()

--- a/lua/ulib/server/entity_ext.lua
+++ b/lua/ulib/server/entity_ext.lua
@@ -118,7 +118,7 @@ local function tool( ply, tr, toolmode, second )
 		end
 	end
 
-    local trTable = getTable( tr.Entity )
+	local trTable = getTable( tr.Entity )
 	if trTable.NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
@@ -130,7 +130,7 @@ end
 hook.Add( "CanTool", "ULibEntToolCheck", tool, HOOK_HIGH )
 
 local function property( _, _, ent )
-    local entTable = getTable( ent )
+	local entTable = getTable( ent )
 	if entTable.NoMoving and not moveWhitelist[toolmode] then
 		return false
 	end
@@ -159,7 +159,7 @@ hook.Add( "OnPhysgunReload", "ULibEntPhysReloadCheck", physgunReload, HOOK_HIGH 
 
 -- This is just in case we have some horribly programmed addon that goes rampant in deleting things
 local function removedCheck( ent )
-    local entTable = getTable( ent )
+	local entTable = getTable( ent )
 	if entTable.NoDeleting and not entTable.NoReplication then
 		local class = ent:GetClass()
 		local pos = ent:GetPos()

--- a/lua/ulib/server/player_ext.lua
+++ b/lua/ulib/server/player_ext.lua
@@ -27,10 +27,6 @@ end
 local entMeta = FindMetaTable( "Entity" )
 local getTable = entMeta.GetTable
 
-local function getKey( ent, key )
-	return getTable( ent )[key]
-end
-
 -- Extended player meta and hooks
 function meta:DisallowNoclip( bool )
 	self.NoNoclip = bool
@@ -47,7 +43,7 @@ end
 local function tool( ply, _, toolmode )
 	if not ply or not ply:IsValid() then return end
 
-	if getKey( ply, "NoSpawning" ) and not spawnWhitelist[toolmode] then
+	if getTable( ply ).NoSpawning and not spawnWhitelist[toolmode] then
 		return false
 	end
 end
@@ -55,13 +51,13 @@ hook.Add( "CanTool", "ULibPlayerToolCheck", tool, HOOK_HIGH )
 
 local function noclip( ply )
 	if not ply or not ply:IsValid() then return end
-	if getKey( ply, "NoNoclip" ) then return false end
+	if getTable( ply ).NoNoclip then return false end
 end
 hook.Add( "PlayerNoClip", "ULibNoclipCheck", noclip, HOOK_HIGH )
 
 local function spawnblock( ply )
 	if not ply or not ply:IsValid() then return end
-	if getKey( ply, "NoSpawning" ) then return false end
+	if getTable( ply ).NoSpawning then return false end
 end
 hook.Add( "PlayerSpawnObject", "ULibSpawnBlock", spawnblock )
 hook.Add( "PlayerSpawnEffect", "ULibSpawnBlock", spawnblock )
@@ -74,7 +70,7 @@ hook.Add( "PlayerGiveSWEP", "ULibSpawnBlock", spawnblock )
 
 local function vehicleblock( ply )
 	if not ply or not ply:IsValid() then return end
-	if getKey( ply, "NoVehicles" ) then
+	if getTable( ply ).NoVehicles then
 		return false
 	end
 end

--- a/lua/ulib/server/player_ext.lua
+++ b/lua/ulib/server/player_ext.lua
@@ -1,4 +1,5 @@
 local meta = FindMetaTable( "Player" )
+if not meta then return end
 
 ULib.spawnWhitelist = -- Tool white list for tools that don't spawn things
 {
@@ -17,9 +18,20 @@ ULib.spawnWhitelist = -- Tool white list for tools that don't spawn things
 	"axis",
 }
 
--- Return if there's nothing to add on to
-if not meta then return end
+-- Performance optimization
+local spawnWhitelist = {}
+for _, v in ipairs( ULib.spawnWhitelist ) do
+	spawnWhitelist[v] = true
+end
 
+local entMeta = FindMetaTable( "Entity" )
+local getTable = entMeta.GetTable
+
+local function getKey( ent, key )
+	return getTable( ent )[key]
+end
+
+-- Extended player meta and hooks
 function meta:DisallowNoclip( bool )
 	self.NoNoclip = bool
 end
@@ -32,26 +44,24 @@ function meta:DisallowVehicles( bool )
 	self.NoVehicles = bool
 end
 
-local function tool( ply, tr, toolmode )
+local function tool( ply, _, toolmode )
 	if not ply or not ply:IsValid() then return end
 
-	if ply.NoSpawning then
-		if not table.HasValue( ULib.spawnWhitelist, toolmode ) then
-			return false
-		end
+	if getKey( ply, "NoSpawning" ) and not spawnWhitelist[toolmode] then
+		return false
 	end
 end
 hook.Add( "CanTool", "ULibPlayerToolCheck", tool, HOOK_HIGH )
 
 local function noclip( ply )
 	if not ply or not ply:IsValid() then return end
-	if ply.NoNoclip then return false end
+	if getKey( ply, "NoNoclip" ) then return false end
 end
 hook.Add( "PlayerNoClip", "ULibNoclipCheck", noclip, HOOK_HIGH )
 
 local function spawnblock( ply )
 	if not ply or not ply:IsValid() then return end
-	if ply.NoSpawning then return false end
+	if getKey( ply, "NoSpawning" ) then return false end
 end
 hook.Add( "PlayerSpawnObject", "ULibSpawnBlock", spawnblock )
 hook.Add( "PlayerSpawnEffect", "ULibSpawnBlock", spawnblock )
@@ -62,9 +72,9 @@ hook.Add( "PlayerSpawnRagdoll", "ULibSpawnBlock", spawnblock )
 hook.Add( "PlayerSpawnSENT", "ULibSpawnBlock", spawnblock )
 hook.Add( "PlayerGiveSWEP", "ULibSpawnBlock", spawnblock )
 
-local function vehicleblock( ply, ent )
+local function vehicleblock( ply )
 	if not ply or not ply:IsValid() then return end
-	if ply.NoVehicles then
+	if getKey( ply, "NoVehicles" ) then
 		return false
 	end
 end


### PR DESCRIPTION
This will speed up these hooks and calls pretty significantly and will help reduce the footprint of ULib.

Example for __index skip:
```lua
local ent = ents.Create( "prop_physics" )
ent:SetModel( "models/props_c17/oildrum001.mdl" )
ent.ExampleKey = true
ent:Spawn()

local meta = FindMetaTable( "Entity" )
local getTable = meta.GetTable

GMN.TestCompare(
function()
    return ent.ExampleKey
end,
function()
    return getTable( ent ).ExampleKey
end
)
```
![image](https://github.com/CFC-Servers/ulib/assets/69946827/e71aa7cd-76bd-4d94-890f-6dcc9593c970)

KV table -> `table.HasValue` is self explanatory 